### PR TITLE
Improve Android missing release keystore in builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,14 +15,29 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def loadSigningConfiguration(String name) {
-    def propertiesFile = file("signing/${name}.properties")
+    def propertiesFile = project.file("signing/${name}.properties") as File
+    if (!propertiesFile.exists()) {
+        throw new FileNotFoundException("""The properties file ${propertiesFile.absolutePath} is missing, 
+did you remember to add the signing configuration to the project for ${name}?
+
+Please refer to the readme for further instructions.""")
+    }
+
     def properties = new Properties()
     properties.load(new FileInputStream(propertiesFile))
     return properties
 }
 
 def getKeystore(String fileName) {
-    return file("signing/${fileName}")
+    def keystoreFile = file("signing/${fileName}") as File
+    if (!keystoreFile.exists()) {
+        throw new FileNotFoundException("""The keystore file ${keystoreFile.absolutePath} is missing, 
+but the signing configuration for the current build variant specifies it as the storeFile.
+Did you remember to add the keystore to the project for this build variant?
+
+Please refer to the readme for further instructions.""")
+    }
+    return keystoreFile
 }
 
 android {
@@ -45,17 +60,17 @@ android {
     signingConfigs {
         debug {
             def debugKeystore = loadSigningConfiguration('debug')
-            keyAlias debugKeystore['keyAlias']
-            keyPassword debugKeystore['keyPassword']
             storeFile getKeystore(debugKeystore['storeFile'])
             storePassword debugKeystore['storePassword']
+            keyAlias debugKeystore['keyAlias']
+            keyPassword debugKeystore['keyPassword']
         }
         release {
             def debugKeystore = loadSigningConfiguration('release')
-            keyAlias debugKeystore['keyAlias']
-            keyPassword debugKeystore['keyPassword']
             storeFile getKeystore(debugKeystore['storeFile'])
             storePassword debugKeystore['storePassword']
+            keyAlias debugKeystore['keyAlias']
+            keyPassword debugKeystore['keyPassword']
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,10 +15,10 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def loadSigningConfiguration(String name) {
-    def propertiesFile = project.file("signing/${name}.properties") as File
+    def propertiesFile = file("signing/${name}.properties") as File
     if (!propertiesFile.exists()) {
         throw new FileNotFoundException("""The properties file ${propertiesFile.absolutePath} is missing, 
-did you remember to add the signing configuration to the project for ${name}?
+did you remember to add the signing configuration to the project for $name?
 
 Please refer to the readme for further instructions.""")
     }
@@ -40,6 +40,21 @@ Please refer to the readme for further instructions.""")
     return keystoreFile
 }
 
+def isSigningConfigurationDefinedFor(String name) {
+    return file("signing/${name}.properties").exists()
+}
+
+def reportMissingSigningConfiguration(String name) {
+    logger.error("""
+
+⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️    
+The signing configuration for Android $name builds is not defined,
+please refer to the readme for further informations on how to set it up.
+⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  
+
+""")
+}
+
 android {
     compileSdkVersion 27
     buildToolsVersion '27.0.2'
@@ -59,18 +74,23 @@ android {
 
     signingConfigs {
         debug {
-            def debugKeystore = loadSigningConfiguration('debug')
-            storeFile getKeystore(debugKeystore['storeFile'])
-            storePassword debugKeystore['storePassword']
-            keyAlias debugKeystore['keyAlias']
-            keyPassword debugKeystore['keyPassword']
+            def configuration = loadSigningConfiguration('debug')
+            storeFile getKeystore(configuration['storeFile'])
+            storePassword configuration['storePassword']
+            keyAlias configuration['keyAlias']
+            keyPassword configuration['keyPassword']
         }
+
         release {
-            def debugKeystore = loadSigningConfiguration('release')
-            storeFile getKeystore(debugKeystore['storeFile'])
-            storePassword debugKeystore['storePassword']
-            keyAlias debugKeystore['keyAlias']
-            keyPassword debugKeystore['keyPassword']
+            if (isSigningConfigurationDefinedFor('release')) {
+                def configuration = loadSigningConfiguration('release')
+                storeFile getKeystore(configuration['storeFile'])
+                storePassword configuration['storePassword']
+                keyAlias configuration['keyAlias']
+                keyPassword configuration['keyPassword']
+            } else {
+                reportMissingSigningConfiguration('release')
+            }
         }
     }
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ two tabs; one for the first day of the conference and one for the 2nd (Jan 23rd 
 Jan 24th). Each tab shows a chronological list of the conference sessions for that
 day. Each session shows as a material card. Clicking on a session will open the
 session in a separate page, and show more detailed information including the full
-session description. We use a hero animation when transitioning from the session 
+session description. We use a hero animation when transitioning from the session
 card to the session page.
 
 The data for the sessions, including the full list of sessions, the title, presenters,
@@ -41,5 +41,48 @@ This is a static image of the conference location.
 ### Feeds page
 
 This is a live Twitter feed of any tweets matching the search term
-`#dartconf OR #flutterio OR #angulardart`. Selecting a tweet will open the cooresponding
-item directly at twitter.io. A pull-down gesture will refresh the tweet data.
+`#dartconf OR #flutterio OR #angulardart`. Selecting a tweet will open the corresponding
+item directly at twitter.com. A pull-down gesture will refresh the tweet data.
+
+## Build the app in release mode (Android)
+
+To build the app in release mode for Android, you will need to provide two files:
+
+ * `android/app/signing/release.keystore`
+ * `android/app/signing/release.properties`
+
+The first file is a standard Android keystore file that is used to sign the application,
+while the properties file contains the informations necessary to access the keystore and
+sign the builds.
+
+If you don't provide these two files, the app building will fail when you try to build or
+run a release version. The debug signing configuration is provided in the Git repo and as
+such no configuration is necessary to run Android debug builds.
+
+### Create a signing configuration for release
+
+To generate a keystore, you need the JDK's `keytool` on your path, then run from the
+project root:
+
+```sh
+$ keytool -genkey -v -keystore android/app/signing/release.keystore \
+    -storepass "{✏️ YOUR STORE PASSWORD}" \
+    -alias "{✏️ YOUR SIGNING KEY NAME, e.g., 'dartconf'}" \
+    -keypass "{✏️ YOUR SIGNING KEY PASSWORD}" \
+    -keyalg RSA -validity 14000
+```
+
+This will generate the signing keystore in `android/app/signing/release.keystore`.
+Next, you will need a properties file containing the signing configuration. You can
+create one by running from the project root:
+
+```sh
+$ tee android/app/signing/release.properties <<EOF
+storeFile=release.keystore
+storePassword={✏️ YOUR STORE PASSWORD}
+keyAlias={✏️ YOUR SIGNING KEY NAME, e.g., 'dartconf'}
+keyPassword={✏️ YOUR SIGNING KEY PASSWORD}
+EOF
+```
+
+Remember to fill in the placeholders in both snippets with the same values!

--- a/readme.md
+++ b/readme.md
@@ -86,3 +86,7 @@ EOF
 ```
 
 Remember to fill in the placeholders in both snippets with the same values!
+
+**Note:** both `release.keystore` and `release.properties` are ignored by Git, and for a
+good reason — you should **never** put signing information in a repository. DO NOT add
+these files to the repository!


### PR DESCRIPTION
This PR improves the handling of the cases in which a release configuration for Android is not available:

 * If the user is trying to **build/run a debug version**, then let them, but flash a massive warning sign informing them of the problem
 * If the user is trying to **build/run a release version**, then still flash the warning, and let the build break (nothing we can do about that anyway, it's enforced by the Android plugin, but at least we provide some better instructions)
 * If the release signing configuration is present, then no warning is issued and everything proceeds normally

In addition to that, exhaustive step-by-step instructions have been added to the readme on how to create the missing release configuration if needed. I suppose we should document them the same for the Play Services json/plist, and for the Twitter API key — if those are missing the build will fail too, but those aren't explained in the readme.

This closes #33.