### PR TITLE
Add ability to open map from the map screen

### DIFF
--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class MapPage extends StatefulWidget {
   static const String title = 'Map';
@@ -29,14 +32,28 @@ class _MapPageState extends State<MapPage> {
         ),
       ),
       floatingActionButton: new Chip(
-        label: new Padding(
-          padding: const EdgeInsets.all(4.0),
-          child: new Text(
-            'Google Los Angeles\n340 Main St, Venice, CA 90291',
-            style: theme.textTheme.subhead,
+        label: new InkWell(
+          onTap: _launchIntent,
+          child: new Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: new Text(
+              'Google Los Angeles\n340 Main St, Venice, CA 90291',
+              style: theme.textTheme.subhead.apply(
+                  color: Colors.blue, decoration: TextDecoration.underline),
+            ),
           ),
         ),
       ),
     );
+  }
+
+  Future<Null> _launchIntent() async {
+    const url =
+        'https://www.google.com/maps/place/Google/@33.9950762,-118.4784572,17z/data=!3m1!4b1!4m5!3m4!1s0x80c2bacf22ee5b65:0x95c465741fbb54b3!8m2!3d33.9950762!4d-118.4762685';
+    if (await canLaunch(url)) {
+      await launch(url);
+    } else {
+      print("Error: could not launch URL.");
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
     sdk: flutter
   http: ^0.11.0
   intl: ^0.15.0
-  url_launcher: ^1.0.0
+  url_launcher: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This uses the `url_launcher` package, which opens the standard map app on Android (usually Google Maps) and the Google Maps mobile website on iOS.

Also makes the address on the Map screen look more clickable.