### PR TITLE
Update dependencies & Android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,7 +57,6 @@ please refer to the readme for further informations on how to set it up.
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.2'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.google.gms:google-services:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.google.gms:google-services:3.2.1'
     }
 }
 

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/lib/src/feeds.dart
+++ b/lib/src/feeds.dart
@@ -308,7 +308,7 @@ class Feed implements Comparable<Feed> {
 }
 
 class FeedManager {
-  final http.Client httpClient = http.Client();
+  final http.Client httpClient = new http.Client();
 
   List<Feed> feeds;
 

--- a/lib/src/feeds.dart
+++ b/lib/src/feeds.dart
@@ -308,7 +308,7 @@ class Feed implements Comparable<Feed> {
 }
 
 class FeedManager {
-  final http.Client httpClient = new http.Client();
+  final http.Client httpClient = http.Client();
 
   List<Feed> feeds;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,13 +2,13 @@ name: dart_conf_flutter
 description: A conference app for DartConf 2018.
 
 dependencies:
-  cloud_firestore: ^0.2.6
-  cupertino_icons: ^0.1.1
+  cloud_firestore: ^0.5.1
+  cupertino_icons: ^0.1.2
   flutter:
     sdk: flutter
   http: ^0.11.3+16
-  intl: ^0.15.2
-  url_launcher: ^2.0.1
+  intl: ^0.15.5
+  url_launcher: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This small PR updates the Flutter and Android dependencies for the app. It does not update Firebase on the Android side because of breaking changes in Firebase 12.0.x which aren't yet compatible with the latest Flutter Firestore plugin.

Note: the changes in the XCode files are not generated by me, they reappear every time I build the app. Seems like something changed in Cocoapods or XCode that causes it.